### PR TITLE
Add table output formatter

### DIFF
--- a/src/Microsoft.Graph.Cli.Core.Tests/IO/OutputFormatterFactoryTest.cs
+++ b/src/Microsoft.Graph.Cli.Core.Tests/IO/OutputFormatterFactoryTest.cs
@@ -24,7 +24,7 @@ public class OutputFormatterFactoryTest {
 
     public class GetFormatterFunction_Should {
         [Theory]
-        [InlineData(FormatterType.TABLE)]
+        [InlineData(FormatterType.NONE)]
         public void ThrowException_On_Invalid_FormatterType(FormatterType formatterType) {
             var factory = OutputFormatterFactory.Instance;
 

--- a/src/Microsoft.Graph.Cli.Core.Tests/IO/TableOutputFormatterTest.cs
+++ b/src/Microsoft.Graph.Cli.Core.Tests/IO/TableOutputFormatterTest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.CommandLine;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Graph.Cli.Core.IO;
+using Moq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Microsoft.Graph.Cli.Core.Tests.IO;
+
+public class TableOutputFormatterTest {
+    public class ConstructTableFunction_Should {
+        [Fact]
+        public void Create_A_Table_With_Single_Column_And_Row_When_Object_With_Value() {
+            var console = new TestConsole();
+            var formatter = new TableOutputFormatter();
+            var content = "{\"x\": \"\", \"value\": 10}";
+            var doc = JsonDocument.Parse(content);
+
+            var table = formatter.ConstructTable(doc);
+
+            Assert.Single(table.Columns);
+            Assert.Single(table.Rows);
+            var headerText = table.Columns[0].Header.GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("Value", headerText);
+            var rowCellText = table.Rows.First()[0].GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("10", rowCellText);
+        }
+
+        [Fact]
+        public void Create_A_Table_Given_An_JSON_Array() {
+            var console = new TestConsole();
+            var formatter = new TableOutputFormatter();
+            var content = "[{\"a\": \"value a\", \"b\": null, \"c\": \"value c\"}, {\"a\": \"value a\", \"b\": \"value b\", \"c\": null}]";
+            var doc = JsonDocument.Parse(content);
+
+            var table = formatter.ConstructTable(doc);
+
+            Assert.Equal(3, table.Columns.Count);
+            Assert.Equal(2, table.Rows.Count);
+            var headerText = table.Columns[0].Header.GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("a", headerText);
+            var row0col1Text = table.Rows.First()[1].GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("-", row0col1Text);
+        }
+
+        [Fact]
+        public void Create_A_Table_Given_An_JSON_ObjectWith_Value_Array() {
+            var console = new TestConsole();
+            var formatter = new TableOutputFormatter();
+            var content = "{\"value\": [{\"a\": \"value a\", \"b\": null, \"c\": \"value c\"}, {\"a\": \"value a\", \"b\": \"value b\", \"c\": null}]}";
+            var doc = JsonDocument.Parse(content);
+
+            var table = formatter.ConstructTable(doc);
+
+            Assert.Equal(3, table.Columns.Count);
+            Assert.Equal(2, table.Rows.Count);
+            var headerText = table.Columns[0].Header.GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("a", headerText);
+            var row0col1Text = table.Rows.First()[1].GetSegments(console).Select(s => s.Text).FirstOrDefault();
+            Assert.Equal("-", row0col1Text);
+        }
+    }
+}

--- a/src/Microsoft.Graph.Cli.Core.Tests/Microsoft.Graph.Cli.Core.Tests.csproj
+++ b/src/Microsoft.Graph.Cli.Core.Tests/Microsoft.Graph.Cli.Core.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.43.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.Graph.Cli.Core/IO/FormatterType.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/FormatterType.cs
@@ -3,5 +3,6 @@ namespace Microsoft.Graph.Cli.Core.IO;
 public enum FormatterType
 {
     JSON,
-    TABLE
+    TABLE,
+    NONE
 }

--- a/src/Microsoft.Graph.Cli.Core/IO/OutputFormatterFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/OutputFormatterFactory.cs
@@ -22,13 +22,19 @@ public sealed class OutputFormatterFactory
         {
             case FormatterType.JSON:
                 return new JsonOutputFormatter();
+            case FormatterType.TABLE:
+                return new TableOutputFormatter();
             default:
                 throw new System.NotSupportedException();
         }
     }
 
     public IOutputFormatter GetFormatter(string format) {
-        var type = Enum.Parse<FormatterType>(format.ToUpper());
+        FormatterType type;
+        var success = Enum.TryParse<FormatterType>(format, true, out type);
+        if (!success) {
+            throw new NotSupportedException();
+        }
         return this.GetFormatter(type);
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/IO/TableOutputFormatter.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/TableOutputFormatter.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Spectre.Console;
+
+namespace Microsoft.Graph.Cli.Core.IO
+{
+
+    public class TableOutputFormatter : IOutputFormatter
+    {
+        public void WriteOutput(string content, IConsole console)
+        {
+            using var doc = JsonDocument.Parse(content);
+            var table = this.ConstructTable(doc);
+            AnsiConsole.Write(table);
+        }
+
+        public void WriteOutput(Stream content, IConsole console)
+        {
+            using var doc = JsonDocument.Parse(content);
+            var table = this.ConstructTable(doc);
+            AnsiConsole.Write(table);
+        }
+
+        private Table ConstructTable(JsonDocument document) {
+            var root = document.RootElement;
+            JsonElement firstElement;
+            JsonElement value;
+            var hasValueProperty = root.TryGetProperty("value", out value);
+            if (hasValueProperty) {
+                root = value;
+            }
+
+            if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() > 0) {
+                var enumerated = root.EnumerateArray();
+                firstElement = enumerated.FirstOrDefault();
+            } else {
+                firstElement = root;
+            }
+
+            var properties = new List<(JsonValueKind,string)>();
+            var table = new Table();
+            if (firstElement.ValueKind != JsonValueKind.Object) {
+                properties.Add((firstElement.ValueKind, "Value"));
+            } else {
+                var restrictedValueKinds = new JsonValueKind[] {
+                    JsonValueKind.Array,
+                    JsonValueKind.Null,
+                    JsonValueKind.Object,
+                    JsonValueKind.Undefined
+                };
+                properties = firstElement.EnumerateObject()
+                    .Where(p => !restrictedValueKinds.Contains(p.Value.ValueKind))
+                    .Select(p => (p.Value.ValueKind, p.Name)).ToList();
+            }
+
+            if (root.ValueKind == JsonValueKind.Array) {
+                foreach (var property in properties)
+                    table.AddColumn(property.Item2, column => {
+                        if (property.Item1 == JsonValueKind.Number)
+                            column.RightAligned().PadLeft(10);
+                    });
+
+                foreach (var row in root.EnumerateArray())
+                {
+                    var rowCols = properties.Select(p => {
+                        var valueKind = p.Item1;
+                        var propertyName = p.Item2;
+                        JsonElement property;
+                        var hasProp = row.TryGetProperty(propertyName, out property);
+                        if (hasProp) {
+                            object? value = null;
+                            switch (valueKind)
+                            {
+                                case JsonValueKind.String:
+                                    value = property.GetString();
+                                    break;
+                                case JsonValueKind.True:
+                                case JsonValueKind.False:
+                                    value = property.GetBoolean();
+                                    break;
+                                case JsonValueKind.Number:
+                                    value = property.GetDecimal();
+                                    break;
+                            }
+                            return new Markup(value?.ToString() ?? "-");
+                        } else {
+                            return new Markup("-");
+                        }
+                    });
+                    table.AddRow(rowCols);
+                }
+            }
+
+            return table;
+        }
+    }
+}

--- a/src/Microsoft.Graph.Cli.Core/IO/TableOutputFormatter.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/TableOutputFormatter.cs
@@ -41,15 +41,13 @@ namespace Microsoft.Graph.Cli.Core.IO
             }
 
             var properties = new List<(JsonValueKind,string)>();
-            var table = new Table();
+            var table = new Table().Expand();
             if (firstElement.ValueKind != JsonValueKind.Object) {
                 properties.Add((firstElement.ValueKind, "Value"));
             } else {
                 var restrictedValueKinds = new JsonValueKind[] {
                     JsonValueKind.Array,
-                    JsonValueKind.Null,
-                    JsonValueKind.Object,
-                    JsonValueKind.Undefined
+                    JsonValueKind.Object
                 };
                 properties = firstElement.EnumerateObject()
                     .Where(p => !restrictedValueKinds.Contains(p.Value.ValueKind))

--- a/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
+++ b/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.43.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21617.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Table output formatter accepts JSON formatted data and constructs a table that is printed in the console. This feature uses the [Spectre.Console table widget](https://spectreconsole.net/widgets/table)

A sample of the output is shown below:
![image](https://user-images.githubusercontent.com/747955/151389707-532982a7-2380-4c95-87ae-2fe9c57f5467.png)

For the moment, only simple top level properties are shown. Properties whose values are of type array or object aren't displayed in the table.