### PR TITLE
Disable automatic authentication

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
@@ -45,6 +45,7 @@ public class AuthenticationServiceFactory {
         {
             ClientId = clientId,
             TenantId = tenantId,
+            DisableAutomaticAuthentication = true,
         };
 
         TokenCachePersistenceOptions tokenCacheOptions = new() { Name = Constants.TokenCacheName };


### PR DESCRIPTION
Disable the automatic login prompt when a user has no session. The automatic login didn't have the correct permissions and would cause errors in the command anyway. The login token acquired in the automatic login prompt was also not cached for subsequent commands.
The application will handle displaying an error to the user instead