### PR TITLE
Make middleware setup static

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/IO/GraphCliClientFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/GraphCliClientFactory.cs
@@ -1,17 +1,15 @@
-using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
-using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
 
 namespace Microsoft.Graph.Cli.Core.IO;
 
 public class GraphCliClientFactory
 {
-    public IEnumerable<DelegatingHandler> GetDefaultMiddlewaresWithOptions(GraphClientOptions options) => GraphClientFactory.CreateDefaultHandlers(options);
+    public static IEnumerable<DelegatingHandler> GetDefaultMiddlewaresWithOptions(GraphClientOptions options) => GraphClientFactory.CreateDefaultHandlers(options);
 
-    public HttpClient GetDefaultClient(GraphClientOptions options, string nationalCloud = GraphClientFactory.Global_Cloud, params DelegatingHandler[] middlewares)
+    public static HttpClient GetDefaultClient(GraphClientOptions options, string nationalCloud = GraphClientFactory.Global_Cloud, params DelegatingHandler[] middlewares)
     {
         IEnumerable<DelegatingHandler> m = middlewares;
         if (!middlewares.Any())


### PR DESCRIPTION
Changes the client creation code from:
```csharp
using var httpClient = new GraphCliClientFactory().GetDefaultClient(options);
```
to:
```csharp
using var httpClient = GraphCliClientFactory.GetDefaultClient(options);
```
Avoids having a `GraphCliClientFactory` instance created