### PR TITLE
Add option to allow MSAL token cache to fall back on unencrypted storage

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LoginCommand.cs
+++ b/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LoginCommand.cs
@@ -39,7 +39,8 @@ public class LoginCommand
         loginCommand.SetHandler<string[], string?, string?, AuthenticationStrategy, IHost, CancellationToken>(async (scopes, clientId, tenantId, strategy, host, cancellationToken) =>
         {
             var authUtil = host.Services.GetRequiredService<IAuthenticationCacheUtility>();
-            var authService = await this.authenticationServiceFactory.GetAuthenticationServiceAsync(strategy, tenantId, clientId, cancellationToken);
+            var options = host.Services.GetRequiredService<IOptionsMonitor<AuthenticationOptions>>().CurrentValue;
+            var authService = await this.authenticationServiceFactory.GetAuthenticationServiceAsync(strategy, tenantId, clientId, options.AllowUnencryptedTokenCache, cancellationToken);
             await authService.LoginAsync(scopes, cancellationToken);
             await authUtil.SaveAuthenticationIdentifiersAsync(clientId, tenantId, cancellationToken);
         }, scopesOption, clientIdOption, tenantIdOption, strategyOption);

--- a/src/Microsoft.Graph.Cli.Core/Configuration/AuthenticationOptions.cs
+++ b/src/Microsoft.Graph.Cli.Core/Configuration/AuthenticationOptions.cs
@@ -4,4 +4,6 @@ public class AuthenticationOptions {
     public string? TenantId { get; set; }
 
     public string? ClientId { get; set; }
+
+    public bool AllowUnencryptedTokenCache { get; set; }
 }


### PR DESCRIPTION
Work around for microsoftgraph/msgraph-cli#69