### PR TITLE
Replace existing auth cache file

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
@@ -8,7 +8,8 @@ using Microsoft.Graph.Cli.Core.Utils;
 
 namespace Microsoft.Graph.Cli.Core.IO;
 
-public class AuthenticationCacheUtility : IAuthenticationCacheUtility {
+public class AuthenticationCacheUtility : IAuthenticationCacheUtility
+{
     private readonly IPathUtility pathUtility;
 
     public AuthenticationCacheUtility(IPathUtility pathUtility)
@@ -25,28 +26,51 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility {
     {
         cancellationToken.ThrowIfCancellationRequested();
         var path = this.GetAuthenticationCacheFilePath();
-        if (!File.Exists(path)) {
+        if (!File.Exists(path))
+        {
             throw new FileNotFoundException();
         }
 
         using var fileStream = File.OpenRead(path);
         var configRoot = await JsonSerializer.DeserializeAsync<Configuration.ConfigurationRoot>(fileStream, cancellationToken: cancellationToken);
         if (configRoot?.AuthenticationOptions is null) throw new AuthenticationIdentifierException("Cannot find cached authentication identifiers.");
-        
+
         return configRoot.AuthenticationOptions;
     }
 
-    public async Task SaveAuthenticationIdentifiersAsync(string? clientId, string? tenantId, CancellationToken cancellationToken = default) {
+    public async Task SaveAuthenticationIdentifiersAsync(string? clientId, string? tenantId, CancellationToken cancellationToken = default)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         var path = this.GetAuthenticationCacheFilePath();
-        var configuration = new Configuration.ConfigurationRoot {
-            AuthenticationOptions = new AuthenticationOptions {
-                ClientId = clientId,
-                TenantId = tenantId
+        var configuration = new Configuration.ConfigurationRoot
+        {
+            AuthenticationOptions = new AuthenticationOptions
+            {
+                ClientId = clientId ?? Constants.DefaultAppId,
+                TenantId = tenantId ?? Constants.DefaultTenant
             }
         };
-        using FileStream fileStream = File.OpenWrite(path);
-        await JsonSerializer.SerializeAsync(fileStream, configuration, cancellationToken: cancellationToken);
+
+        await WriteConfigurationAsync(path, configuration, cancellationToken);
+    }
+
+    private async Task WriteConfigurationAsync(string path, ConfigurationRoot configuration, CancellationToken cancellationToken = default, int retryCount = 0)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+            using FileStream fileStream = File.OpenWrite(path);
+            await JsonSerializer.SerializeAsync(fileStream, configuration, cancellationToken: cancellationToken);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            Directory.CreateDirectory(path);
+            if (retryCount < 1)
+                await WriteConfigurationAsync(path, configuration, cancellationToken, retryCount + 1);
+        }
     }
 
     public class AuthenticationIdentifierException : Exception

--- a/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
+++ b/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
@@ -14,7 +14,7 @@
     <Deterministic>true</Deterministic>
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
-    <Version>0.1.0-preview.1</Version>
+    <Version>0.1.1-preview.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fix prevents file corruption when the new serialized JSON is of a different length to the previously stored file. The serializer only replaces the destination file contents up to the length of the stream.

Consider an existing file with the content `{"key1": "1000", "key2": "2000"}`. If we open the file again and serialize new content `{"key1": "10", "key2": "20"}`, then the new modified file content will be `{"key1": "10", "key2": "20"}00"}` which is invalid json. Parsing this new file will inevitably fail.