### PR TITLE
Feat/delete token cache

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MGC_Logging__LogLevel__Microsoft.Graph.Cli=Debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,34 +10,66 @@
             "request": "launch",
             "preLaunchTask": "build sample",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/sample/bin/Debug/net6.0/sample.dll",
+            "program": "${workspaceFolder}/src/sample/bin/Debug/net7.0/sample.dll",
             "args": ["login", "--strategy", "InteractiveBrowser"],
             "cwd": "${workspaceFolder}/src/sample",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "envFile": "${workspaceFolder}/.env"
+        },
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": "login device code (sample)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build sample",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/sample/bin/Debug/net7.0/sample.dll",
+            "args": ["login", "--strategy", "DeviceCode"],
+            "cwd": "${workspaceFolder}/src/sample",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "envFile": "${workspaceFolder}/.env"
         },
         {
             "name": "login certificate name (sample)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build sample",
-            "program": "${workspaceFolder}/src/sample/bin/Debug/net6.0/sample.dll",
+            "program": "${workspaceFolder}/src/sample/bin/Debug/net7.0/sample.dll",
             "args": ["login", "--strategy", "ClientCertificate", "--tenant-id", "39aafea4-2975-4790-9c07-e616c1c35d99", "--client-id", "e49807f2-94cc-4f59-9e14-be2a37eab7c2", "--certificate-name", "CN=TestCertificate"],
             "cwd": "${workspaceFolder}/src/sample",
             "console": "internalConsole",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "envFile": "${workspaceFolder}/.env"
         },
         {
             "name": "users list (sample)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build sample",
-            "program": "${workspaceFolder}/src/sample/bin/Debug/net6.0/sample.dll",
+            "program": "${workspaceFolder}/src/sample/bin/Debug/net7.0/sample.dll",
             "args": ["users", "--debug"],
             "cwd": "${workspaceFolder}/src/sample",
             "console": "integratedTerminal",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "envFile": "${workspaceFolder}/.env"
+        },
+        {
+            "name": "logout (sample)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build sample",
+            "program": "${workspaceFolder}/src/sample/bin/Debug/net7.0/sample.dll",
+            "args": ["logout", "--debug"],
+            "cwd": "${workspaceFolder}/src/sample",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "envFile": "${workspaceFolder}/.env"
         },
         {
             "name": ".NET Core Attach",

--- a/src/Microsoft.Graph.Cli.Core.Tests/Commands/Authentication/LoginCommandTest.cs
+++ b/src/Microsoft.Graph.Cli.Core.Tests/Commands/Authentication/LoginCommandTest.cs
@@ -17,7 +17,8 @@ public class LoginCommandTest
     {
         // Given
         var pathUtilityMock = new Mock<IPathUtility>();
-        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, new AuthenticationOptions());
+        var cacheUtilityMock = new Mock<IAuthenticationCacheUtility>();
+        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, cacheUtilityMock.Object, new AuthenticationOptions());
         var loginCommandBuilder = new LoginCommand(authServiceFactoryMock.Object);
         var command = loginCommandBuilder.Build();
         var parser = new Parser(command);
@@ -35,7 +36,8 @@ public class LoginCommandTest
     {
         // Given
         var pathUtilityMock = new Mock<IPathUtility>();
-        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, new AuthenticationOptions());
+        var cacheUtilityMock = new Mock<IAuthenticationCacheUtility>();
+        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, cacheUtilityMock.Object, new AuthenticationOptions());
         var loginCommandBuilder = new LoginCommand(authServiceFactoryMock.Object);
         var command = loginCommandBuilder.Build();
         var parser = new Parser(command);
@@ -56,7 +58,8 @@ public class LoginCommandTest
     {
         // Given
         var pathUtilityMock = new Mock<IPathUtility>();
-        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, new AuthenticationOptions());
+        var cacheUtilityMock = new Mock<IAuthenticationCacheUtility>();
+        var authServiceFactoryMock = new Mock<AuthenticationServiceFactory>(pathUtilityMock.Object, cacheUtilityMock.Object, new AuthenticationOptions());
         var loginCommandBuilder = new LoginCommand(authServiceFactoryMock.Object);
         var command = loginCommandBuilder.Build();
         var parser = new Parser(command);

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
@@ -19,3 +19,15 @@ public enum AuthenticationStrategy
     /// </summary>
     ClientCertificate
 }
+
+public static class AuthenticationStrategyExtensions {
+    public static bool IsPrivateClient(this AuthenticationStrategy strategy)
+    {
+        return strategy switch
+        {
+            AuthenticationStrategy.DeviceCode or AuthenticationStrategy.InteractiveBrowser => false,
+            AuthenticationStrategy.ClientCertificate => true,
+            _ => throw new System.ArgumentOutOfRangeException(nameof(strategy), strategy, "The authentication strategy is invalid")
+        };
+    }
+}

--- a/src/Microsoft.Graph.Cli.Core/Authentication/ClientCertificateCredentialFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/ClientCertificateCredentialFactory.cs
@@ -34,7 +34,8 @@ public static class ClientCertificateCredentialFactory
         // //         at Microsoft.Identity.Client.TokenCache.Microsoft.Identity.Client.ITokenCacheSerializer.DeserializeMsalV3(Byte[] msalV3State, Boolean shouldClearExistingCache)
         // //         at Microsoft.Identity.Client.Extensions.Msal.MsalCacheHelper.BeforeAccessNotification(TokenCacheNotificationArgs args)
         // //      MsalCacheHelperSingleton Error: 0 : [MSAL.Extension][2022 - 08 - 05T12: 28:16.5681763Z] No data found in the store, clearing the cache in memory.
-        // TokenCachePersistenceOptions tokenCacheOptions = new() { Name = Constants.TokenCacheName };
+        // TODO: Investigate how to clear confidential client cache. What accountId is used with the GetAccountAsync & RemoveAsync functions?
+        // TokenCachePersistenceOptions tokenCacheOptions = new() { Name = Microsoft.Graph.Cli.Core.Utils.Constants.TokenCacheName };
         // credOptions.TokenCachePersistenceOptions = tokenCacheOptions;
 
         X509Certificate2? certificate;
@@ -57,7 +58,7 @@ public static class ClientCertificateCredentialFactory
     /// <param name="certificateNameOrThumbPrint">Subject name or thumb print of the certificate to get.</param>
     /// <param name="isThumbPrint">If true, try to find the certificate by the thumb print.</param>
     /// <returns>A matching unexpired certificate.</returns>
-    private static bool TryGetCertificateFromStore(string certNameOrThumbPrint, bool isThumbPrint, out X509Certificate2? certificate)
+    internal static bool TryGetCertificateFromStore(string certNameOrThumbPrint, bool isThumbPrint, out X509Certificate2? certificate)
     {
         certificate = null;
         // Get the certificate store for the current user.

--- a/src/Microsoft.Graph.Cli.Core/Authentication/LogoutService.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/LogoutService.cs
@@ -1,6 +1,6 @@
-using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Graph.Cli.Core.IO;
-using Microsoft.Graph.Cli.Core.Utils;
 
 namespace Microsoft.Graph.Cli.Core.Authentication;
 
@@ -13,9 +13,8 @@ public class LogoutService
         this.authCacheUtility = authCacheUtility;
     }
 
-    public void Logout()
+    public async Task Logout(CancellationToken cancellationToken = default)
     {
-        authCacheUtility.DeleteAuthenticationIdentifiers();
-        authCacheUtility.DeleteAuthenticationRecord();
+        await authCacheUtility.ClearTokenCache(cancellationToken);
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LogoutCommand.cs
+++ b/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LogoutCommand.cs
@@ -1,7 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Graph.Cli.Core.Authentication;
-using Microsoft.Graph.Cli.Core.Utils;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.Threading;
 
 namespace Microsoft.Graph.Cli.Core.Commands.Authentication;
 
@@ -15,9 +15,10 @@ public class LogoutCommand
 
     public Command Build() {
         var logoutCommand = new Command("logout", "Logout by deleting the stored session used in commands");
-        logoutCommand.SetHandler(() =>
+        logoutCommand.SetHandler(async (context) =>
         {
-            this.logoutService.Logout();
+            var cancellationToken = context.BindingContext.GetRequiredService<CancellationToken>();
+            await this.logoutService.Logout(cancellationToken);
         });
 
         return logoutCommand;

--- a/src/Microsoft.Graph.Cli.Core/Configuration/AuthenticationOptions.cs
+++ b/src/Microsoft.Graph.Cli.Core/Configuration/AuthenticationOptions.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Graph.Cli.Core.Configuration;
 
 public class AuthenticationOptions
 {
+    public string? Authority { get; set; }
+
     public string? TenantId { get; set; }
 
     public string? ClientId { get; set; }

--- a/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ using Microsoft.Graph.Cli.Core.Configuration;
 using Microsoft.Graph.Cli.Core.Utils;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
-using Microsoft.IdentityModel.Abstractions;
 
 namespace Microsoft.Graph.Cli.Core.IO;
 
@@ -107,17 +105,6 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         var isPrivate = IsPrivateClient(options.Strategy);
 
         IClientApplicationBase app;
-        var authority = options?.Authority?.Trim();
-        if (!string.IsNullOrEmpty(authority))
-        {
-            if (!authority.StartsWith("http"))
-            {
-                authority = $"https://{authority}";
-            }
-
-            authority = $"{authority}/{tenantId}";
-        }
-
         // MSAL doesn't have an API to clear the token cache on confidential clients.
         // See https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-clear-token-cache#web-api-and-daemon-apps
         if (!isPrivate)
@@ -236,27 +223,6 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
 
         public AuthenticationIdentifierException(string? message, Exception? innerException) : base(message, innerException)
         {
-        }
-    }
-
-    class IdentityLogger : IIdentityLogger
-    {
-        public EventLogLevel MinLogLevel { get; }
-
-        public IdentityLogger()
-        {
-            MinLogLevel = EventLogLevel.LogAlways;
-        }
-
-        public bool IsEnabled(EventLogLevel eventLogLevel)
-        {
-            return eventLogLevel <= MinLogLevel;
-        }
-
-        public void Log(LogEntry entry)
-        {
-            //Log Message here:
-            Console.WriteLine(entry.Message);
         }
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
@@ -102,12 +102,10 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
             return;
         }
 
-        var isPrivate = IsPrivateClient(options.Strategy);
-
         IClientApplicationBase app;
         // MSAL doesn't have an API to clear the token cache on confidential clients.
         // See https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-clear-token-cache#web-api-and-daemon-apps
-        if (!isPrivate)
+        if (!options.Strategy.IsPrivateClient())
         {
             var cacheHelper = await GetProtectedCacheHelperAsync(Constants.TokenCacheName, cancellationToken);
             var appBuilder = PublicClientApplicationBuilder.Create(clientId);
@@ -127,16 +125,6 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
 
         DeleteAuthenticationIdentifiers();
         DeleteAuthenticationRecord();
-    }
-
-    private bool IsPrivateClient(AuthenticationStrategy strategy)
-    {
-        return strategy switch
-        {
-            AuthenticationStrategy.DeviceCode or AuthenticationStrategy.InteractiveBrowser => false,
-            AuthenticationStrategy.ClientCertificate => true,
-            _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "The authentication strategy is invalid")
-        };
     }
 
     private void DeleteAuthenticationIdentifiers()

--- a/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
@@ -109,7 +109,7 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         // See https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-clear-token-cache#web-api-and-daemon-apps
         if (!isPrivate)
         {
-            var cacheHelper = await GetProtectedCacheHelperAsync(Constants.TokenCacheName);
+            var cacheHelper = await GetProtectedCacheHelperAsync(Constants.TokenCacheName, cancellationToken);
             var appBuilder = PublicClientApplicationBuilder.Create(clientId);
             app = appBuilder.Build();
 
@@ -194,7 +194,7 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         }
     }
 
-    private async Task<MsalCacheHelper> GetProtectedCacheHelperAsync(string name)
+    private async Task<MsalCacheHelper> GetProtectedCacheHelperAsync(string name, CancellationToken cancellationToken = default)
     {
         // https://github.com/Azure/azure-sdk-for-net/blob/4b2579556b7271587d2fb122163e23090a043597/sdk/identity/Azure.Identity/src/Constants.cs
         string cacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ".IdentityService");

--- a/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/AuthenticationCacheUtility.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Graph.Cli.Core.Authentication;
 using Microsoft.Graph.Cli.Core.Configuration;
 using Microsoft.Graph.Cli.Core.Utils;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+using Microsoft.IdentityModel.Abstractions;
 
 namespace Microsoft.Graph.Cli.Core.IO;
 
@@ -44,17 +50,22 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         var path = this.GetAuthenticationCacheFilePath();
         ConfigurationRoot configuration = await ReadConfigurationAsync(cancellationToken) ?? new Configuration.ConfigurationRoot();
         var authOptions = configuration.AuthenticationOptions;
+        var adAuthority = Constants.DefaultAuthority;
         clientId = clientId ?? Constants.DefaultAppId;
         tenantId = tenantId ?? Constants.DefaultTenant;
+
+        // TODO: Verify the auth record matches the auth options supplied.
 
         // Only write auth configuration if the values have changed
         if (
                 clientId != authOptions.ClientId || tenantId != authOptions.TenantId || certificateName != authOptions.ClientCertificateName ||
-                certificateThumbPrint != authOptions.ClientCertificateThumbPrint || strategy != authOptions.Strategy
+                certificateThumbPrint != authOptions.ClientCertificateThumbPrint || strategy != authOptions.Strategy ||
+                adAuthority != authOptions.Authority
         )
         {
             configuration.AuthenticationOptions = new AuthenticationOptions
             {
+                Authority = adAuthority,
                 ClientId = clientId,
                 TenantId = tenantId,
                 ClientCertificateName = certificateName,
@@ -66,7 +77,115 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         }
     }
 
-    public void DeleteAuthenticationIdentifiers()
+    public async Task<AuthenticationRecord?> ReadAuthenticationRecordAsync(CancellationToken cancellationToken = default)
+    {
+        var recordPath = Path.Combine(pathUtility.GetApplicationDataDirectory(), Constants.AuthRecordPath);
+        AuthenticationRecord? record = null;
+
+        if (File.Exists(recordPath))
+        {
+            using var authRecordStream = new FileStream(recordPath, FileMode.Open, FileAccess.Read);
+            var authRecord = await AuthenticationRecord.DeserializeAsync(authRecordStream, cancellationToken);
+            record = authRecord;
+        }
+
+        return record;
+    }
+    public async Task ClearTokenCache(CancellationToken cancellationToken = default)
+    {
+        // https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-net-clear-token-cache
+        // Work-around until https://github.com/Azure/azure-sdk-for-net/issues/32048 is resolved
+        var options = await ReadAuthenticationIdentifiersAsync(cancellationToken);
+        var record = await ReadAuthenticationRecordAsync(cancellationToken);
+        var clientId = record?.ClientId ?? options?.ClientId;
+        var tenantId = record?.TenantId ?? options?.TenantId;
+        if (options == null || string.IsNullOrWhiteSpace(clientId))
+        {
+            return;
+        }
+
+        var isPrivate = IsPrivateClient(options.Strategy);
+
+        IClientApplicationBase app;
+        var authority = options?.Authority?.Trim();
+        if (!string.IsNullOrEmpty(authority))
+        {
+            if (!authority.StartsWith("http"))
+            {
+                authority = $"https://{authority}";
+            }
+
+            authority = $"{authority}/{tenantId}";
+        }
+
+        var cacheHelper = await GetProtectedCacheHelperAsync(Constants.TokenCacheName);
+        if (isPrivate)
+        {
+            var appBuilder = ConfidentialClientApplicationBuilder.Create(clientId).WithTenantId(tenantId);
+            if (!string.IsNullOrEmpty(authority)) {
+                appBuilder.WithAuthority(authority);
+            }
+            if (options?.Strategy == AuthenticationStrategy.ClientCertificate)
+            {
+                X509Certificate2? cert;
+                string? certOrThumb = options.ClientCertificateName ?? options.ClientCertificateThumbPrint;
+                bool isThumbPrint = string.IsNullOrWhiteSpace(options.ClientCertificateName);
+                if (!string.IsNullOrWhiteSpace(certOrThumb) && ClientCertificateCredentialFactory.TryGetCertificateFromStore(certOrThumb, isThumbPrint, out cert))
+                {
+                    appBuilder.WithCertificate(cert);
+                }
+            }
+            appBuilder.WithExperimentalFeatures().WithLogging(new IdentityLogger(), true);
+            app = appBuilder.Build();
+        }
+        else
+        {
+            var appBuilder = PublicClientApplicationBuilder.Create(clientId);
+            app = appBuilder.Build();
+        }
+        
+        cacheHelper.RegisterCache(app.UserTokenCache);
+        if (app is IConfidentialClientApplication cca) cacheHelper.RegisterCache(cca.AppTokenCache);
+
+        var accounts = await app.GetAccountsAsync();
+        var accountsIter = accounts.GetEnumerator();
+        while (accountsIter.MoveNext())
+        {
+            await app.RemoveAsync(accountsIter.Current);
+        }
+
+        cacheHelper.UnregisterCache(app.UserTokenCache);
+        if (app is IConfidentialClientApplication cca1 && options?.Strategy == AuthenticationStrategy.ClientCertificate)
+        {
+            // IEnumerable<string> scopes = new string[] {Constants.DefaultCertificateScope};
+            // var tokenResp =  await cca1
+            //    .AcquireTokenForClient(scopes)
+            //    .ExecuteAsync();
+            
+            // if (tokenResp?.AuthenticationResultMetadata?.TokenSource == TokenSource.Cache) {
+            //     // Delete from cache.
+            //     // How?
+            //     // var resp = await cca1.AcquireTokenSilent(scopes, tokenResp!.Account).ExecuteAsync();
+            //     var account = await cca1.GetAccountAsync($"{clientId}_{tenantId}_AppTokenCache");
+            //     await cca1.RemoveAsync(tokenResp?.Account);
+            // }
+            cacheHelper.UnregisterCache(cca1.AppTokenCache);
+        }
+        DeleteAuthenticationIdentifiers();
+        DeleteAuthenticationRecord();
+    }
+
+    private bool IsPrivateClient(AuthenticationStrategy strategy)
+    {
+        return strategy switch
+        {
+            AuthenticationStrategy.DeviceCode or AuthenticationStrategy.InteractiveBrowser => false,
+            AuthenticationStrategy.ClientCertificate => true,
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "The authentication strategy is invalid")
+        };
+    }
+
+    private void DeleteAuthenticationIdentifiers()
     {
         var authIdentifierPath = GetAuthenticationCacheFilePath();
         if (File.Exists(authIdentifierPath))
@@ -75,7 +194,7 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         }
     }
 
-    public void DeleteAuthenticationRecord()
+    private void DeleteAuthenticationRecord()
     {
         var authRecordPath = Path.Combine(pathUtility.GetApplicationDataDirectory(), Constants.AuthRecordPath);
         if (File.Exists(authRecordPath))
@@ -121,6 +240,23 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
         }
     }
 
+    private async Task<MsalCacheHelper> GetProtectedCacheHelperAsync(string name)
+    {
+        // https://github.com/Azure/azure-sdk-for-net/blob/4b2579556b7271587d2fb122163e23090a043597/sdk/identity/Azure.Identity/src/Constants.cs
+        string cacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ".IdentityService");
+        const string keychainService = "Microsoft.Developer.IdentityService";
+        const string keyringSchema = "msal.cache";
+        const string keyringCollection = "default";
+        KeyValuePair<string, string> keyringAttribute1 = new("MsalClientID", "Microsoft.Developer.IdentityService");
+        KeyValuePair<string, string> keyringAttribute2 = new("Microsoft.Developer.IdentityService", "1.0.0.0");
+        StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(name, cacheDir)
+            .WithMacKeyChain(keychainService, name)
+            .WithLinuxKeyring(keyringSchema, keyringCollection, name, keyringAttribute1, keyringAttribute2)
+            .Build();
+
+        return await MsalCacheHelper.CreateAsync(storageProperties);
+    }
+
     public class AuthenticationIdentifierException : Exception
     {
         public AuthenticationIdentifierException()
@@ -133,6 +269,27 @@ public class AuthenticationCacheUtility : IAuthenticationCacheUtility
 
         public AuthenticationIdentifierException(string? message, Exception? innerException) : base(message, innerException)
         {
+        }
+    }
+
+    class IdentityLogger : IIdentityLogger
+    {
+        public EventLogLevel MinLogLevel { get; }
+
+        public IdentityLogger()
+        {
+            MinLogLevel = EventLogLevel.LogAlways;
+        }
+
+        public bool IsEnabled(EventLogLevel eventLogLevel)
+        {
+            return eventLogLevel <= MinLogLevel;
+        }
+
+        public void Log(LogEntry entry)
+        {
+            //Log Message here:
+            Console.WriteLine(entry.Message);
         }
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/IO/IAuthenticationCacheUtility.cs
+++ b/src/Microsoft.Graph.Cli.Core/IO/IAuthenticationCacheUtility.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Graph.Cli.Core.Authentication;
 using Microsoft.Graph.Cli.Core.Configuration;
 
@@ -13,7 +14,7 @@ public interface IAuthenticationCacheUtility
 
     Task<AuthenticationOptions> ReadAuthenticationIdentifiersAsync(CancellationToken cancellationToken = default);
 
-    void DeleteAuthenticationIdentifiers();
+    Task<AuthenticationRecord?> ReadAuthenticationRecordAsync(CancellationToken cancellationToken = default);
 
-    void DeleteAuthenticationRecord();
+    Task ClearTokenCache(CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
+++ b/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
@@ -14,13 +14,13 @@
     <Deterministic>true</Deterministic>
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
-    <Version>0.1.5-preview.1</Version>
+    <Version>0.1.6-preview.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.8.1" />
     <PackageReference Include="JmesPath.Net" Version="1.0.205" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.0-rc.3" />
     <PackageReference Include="Microsoft.Kiota.Cli.Commons" Version="0.1.12-preview.1" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-rc.4" />

--- a/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
+++ b/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="JmesPath.Net" Version="1.0.205" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.0-rc.3" />
-    <PackageReference Include="Microsoft.Kiota.Cli.Commons" Version="0.1.12-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Cli.Commons" Version="0.1.12-preview.2" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-rc.5" />
     <PackageReference Include="Spectre.Console" Version="0.46.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/src/Microsoft.Graph.Cli.Core/utils/Constants.cs
+++ b/src/Microsoft.Graph.Cli.Core/utils/Constants.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Graph.Cli.Core.Utils
         
         public const string DefaultTenant = "common";
 
+        public const string DefaultAuthority = "https://login.microsoftonline.com";
+
+        public const string DefaultCertificateScope = "https://graph.microsoft.com/.default";
+
         public const AuthenticationStrategy defaultAuthStrategy = AuthenticationStrategy.DeviceCode;
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/utils/Constants.cs
+++ b/src/Microsoft.Graph.Cli.Core/utils/Constants.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Graph.Cli.Core.Utils
 
         public const string DefaultAuthority = "https://login.microsoftonline.com";
 
-        public const string DefaultCertificateScope = "https://graph.microsoft.com/.default";
-
         public const AuthenticationStrategy defaultAuthStrategy = AuthenticationStrategy.DeviceCode;
     }
 }

--- a/src/sample/Program.cs
+++ b/src/sample/Program.cs
@@ -115,8 +115,7 @@ namespace Microsoft.Graph.Cli
 
             var parser = builder.Build();
 
-            var exitCode = await parser.InvokeAsync(args);
-            return exitCode;
+            return await parser.InvokeAsync(args);
         }
 
         static CommandLineBuilder BuildCommandLine(IEnumerable<Command> commands)

--- a/src/sample/Program.cs
+++ b/src/sample/Program.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Graph.Cli
 
             var authSettings = config.GetSection(nameof(AuthenticationOptions)).Get<AuthenticationOptions>();
             var pathUtil = new PathUtility();
-            var authServiceFactory = new AuthenticationServiceFactory(pathUtil, authSettings);
+            var cacheUtility = new AuthenticationCacheUtility(pathUtil);
+            var authServiceFactory = new AuthenticationServiceFactory(pathUtil, cacheUtility, authSettings);
             AuthenticationStrategy authStrategy = authSettings?.Strategy ?? AuthenticationStrategy.DeviceCode;
 
             using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger(EventLevel.LogAlways);
@@ -108,11 +109,14 @@ namespace Microsoft.Graph.Cli
                     context.Console.Error.WriteLine(ex.Message);
                     Console.ResetColor();
                 }
+
+                context.ExitCode = -1;
             });
 
             var parser = builder.Build();
 
-            return await parser.InvokeAsync(args);
+            var exitCode = await parser.InvokeAsync(args);
+            return exitCode;
         }
 
         static CommandLineBuilder BuildCommandLine(IEnumerable<Command> commands)

--- a/src/sample/sample.csproj
+++ b/src/sample/sample.csproj
@@ -8,9 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Graph.Cli.Core" Version="0.1.2-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0-rc.3" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0-rc.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
Delete tokens from the token cache on logout. see microsoftgraph/msgraph-cli#224

Confidential clients (e.g. client certificate) don't have an API on MSAL to delete tokens, so caching has been disabled for them. This might be a blocker for client secret.