### PR TITLE
Revert "Bump Azure.Identity from 1.9.0 to 1.10.0"

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
+++ b/src/Microsoft.Graph.Cli.Core/Microsoft.Graph.Cli.Core.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <!-- https://github.com/Azure/azure-sdk-for-net/issues/38431 -->
-    <PackageReference Include="Azure.Identity" Version="1.10.0" />
+    <PackageReference Include="Azure.Identity" Version="1.9.0" />
     <PackageReference Include="JmesPath.Net" Version="1.0.308" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-cli-core#254

This version of azure has a bug