### PR TITLE
Adds support for Managed Identity to auth strategy

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/Authentication/AppOnlyLoginService.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AppOnlyLoginService.cs
@@ -1,8 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Graph.Cli.Core.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Graph.Cli.Core.Authentication;
 
@@ -17,6 +17,7 @@ public class AppOnlyLoginService<T> : LoginServiceBase where T : TokenCredential
 
     protected override Task<AuthenticationRecord?> DoLoginAsync(string[] scopes, CancellationToken cancellationToken = default)
     {
+        // TODO: Verify if auth is supported for app only.
         return Task.FromResult<AuthenticationRecord?>(null);
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AppOnlyLoginService.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AppOnlyLoginService.cs
@@ -1,8 +1,8 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Graph.Cli.Core.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Graph.Cli.Core.Authentication;
 
@@ -17,7 +17,6 @@ public class AppOnlyLoginService<T> : LoginServiceBase where T : TokenCredential
 
     protected override Task<AuthenticationRecord?> DoLoginAsync(string[] scopes, CancellationToken cancellationToken = default)
     {
-        // TODO: Verify if auth is supported for app only.
         return Task.FromResult<AuthenticationRecord?>(null);
     }
 }

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
@@ -42,13 +42,13 @@ public class AuthenticationServiceFactory
         {
             return new AppOnlyLoginService<ClientCertificateCredential>(GetClientCertificateCredential(tenantId, clientId, certificateName, certificateThumbPrint), pathUtility);
         }
-        else if (strategy == AuthenticationStrategy.Environment && credential is EnvironmentCredential envCred)
-        {
-            return new AppOnlyLoginService<EnvironmentCredential>(envCred, pathUtility);
-        }
         else if (strategy == AuthenticationStrategy.ManagedIdentity && credential is ManagedIdentityCredential managedIdentityCred)
         {
             return new AppOnlyLoginService<ManagedIdentityCredential>(managedIdentityCred, pathUtility);
+        }
+        else if (strategy == AuthenticationStrategy.Environment && credential is EnvironmentCredential envCred)
+        {
+            return new AppOnlyLoginService<EnvironmentCredential>(envCred, pathUtility);
         }
         else
         {

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Graph.Cli.Core.Configuration;
 using Microsoft.Graph.Cli.Core.IO;
 using Microsoft.Graph.Cli.Core.Utils;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Graph.Cli.Core.Authentication;
 
@@ -46,6 +46,10 @@ public class AuthenticationServiceFactory
         {
             return new AppOnlyLoginService<EnvironmentCredential>(envCred, pathUtility);
         }
+        else if (strategy == AuthenticationStrategy.ManagedIdentity && credential is ManagedIdentityCredential managedIdentityCred)
+        {
+            return new AppOnlyLoginService<ManagedIdentityCredential>(managedIdentityCred, pathUtility);
+        }
         else
         {
             throw new InvalidOperationException($"The authentication strategy {strategy} is not supported");
@@ -64,6 +68,8 @@ public class AuthenticationServiceFactory
                 return GetClientCertificateCredential(tenantId, clientId, certificateName, certificateThumbPrint);
             case AuthenticationStrategy.Environment:
                 return new EnvironmentCredential(tenantId, clientId);
+            case AuthenticationStrategy.ManagedIdentity:
+                return new ManagedIdentityCredential(clientId);
             default:
                 throw new InvalidOperationException($"The authentication strategy {strategy} is not supported");
         }

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
@@ -21,7 +21,11 @@ public enum AuthenticationStrategy
     /// <summary>
     /// Environment strategy. Enables authentication using environment variables. Supports certificate file & client secret login
     /// </summary>
-    Environment
+    Environment,
+    /// <summary>
+    /// Managed Identity strategy. Enables authentication using a managed identity.
+    /// </summary>
+    ManagedIdentity
 }
 
 public static class AuthenticationStrategyExtensions
@@ -31,7 +35,7 @@ public static class AuthenticationStrategyExtensions
         return strategy switch
         {
             AuthenticationStrategy.DeviceCode or AuthenticationStrategy.InteractiveBrowser => false,
-            AuthenticationStrategy.ClientCertificate or AuthenticationStrategy.Environment => true,
+            AuthenticationStrategy.ClientCertificate or AuthenticationStrategy.Environment or AuthenticationStrategy.ManagedIdentity => true,
             _ => throw new System.ArgumentOutOfRangeException(nameof(strategy), strategy, "The authentication strategy is invalid")
         };
     }

--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationStrategy.cs
@@ -19,13 +19,13 @@ public enum AuthenticationStrategy
     /// </summary>
     ClientCertificate,
     /// <summary>
-    /// Environment strategy. Enables authentication using environment variables. Supports certificate file & client secret login
-    /// </summary>
-    Environment,
-    /// <summary>
     /// Managed Identity strategy. Enables authentication using a managed identity.
     /// </summary>
-    ManagedIdentity
+    ManagedIdentity,
+    /// <summary>
+    /// Environment strategy. Enables authentication using environment variables. Supports certificate file & client secret login
+    /// </summary>
+    Environment
 }
 
 public static class AuthenticationStrategyExtensions

--- a/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LoginCommand.cs
+++ b/src/Microsoft.Graph.Cli.Core/Commands/Authentication/LoginCommand.cs
@@ -1,10 +1,10 @@
-using System.CommandLine;
-using System.CommandLine.Builder;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Graph.Cli.Core.Authentication;
 using Microsoft.Graph.Cli.Core.IO;
 using Microsoft.Graph.Cli.Core.Utils;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.Text;
 
 namespace Microsoft.Graph.Cli.Core.Commands.Authentication;
 
@@ -69,6 +69,8 @@ public sealed class LoginCommand : Command
                 builder.Append(": Open a browser on this computer to log in.\n    ");
                 builder.Append(nameof(AuthenticationStrategy.ClientCertificate));
                 builder.Append(":  Use a certificate stored on this computer's certificate store to sign in. The certificate must have a private key available.\n    ");
+                builder.Append(nameof(AuthenticationStrategy.ManagedIdentity));
+                builder.Append(": Use the managed identity of the Azure resource to log in. \n    ");
                 builder.Append(nameof(AuthenticationStrategy.Environment));
                 builder.Append(":        Use values stored in environment variables to log in.");
                 builder.Append($"\n      Supported environment variables:");


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-cli/issues/163 by adding support for user assigned and system assigned identity to CLI.

### Proposed Usage
#### System Assigned Identity (Cloud Shell)
`mgc login --strategy ManagedIdentity`
``` bash
peter [ ~/linux-x64 ]$ ./mgc login --strategy ManagedIdentity
peter [ ~/linux-x64 ]$ ./mgc users list --select id --top 3
[Warning] Azure-Identity: User assigned managed identities are not supported in the Cloud Shell environment.
{
  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users(id)",
  "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$top=3\u0026$select=id\u0026$skiptoken=XYZ",
  "value": [
    {
      "id": "cf8a5585-6183-467c-ba64-cc34f395880d"
    },
    {
      "id": "e7c47174-7aaf-49e1-ae30-88e9af639bd0"
    },
    {
      "id": "e272b7d2-aa05-4a66-8abc-6f507ee2d81c"
    }
  ]
}
```
#### User Assigned Identity (VM)
`mgc login --strategy ManagedIdentity --client-id "YOUR_MANAGED_IDENTITY_ID"`
