### PR TITLE
Remove login hint

### DIFF
--- a/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
+++ b/src/Microsoft.Graph.Cli.Core/Authentication/AuthenticationServiceFactory.cs
@@ -103,7 +103,6 @@ public class AuthenticationServiceFactory
         TokenCachePersistenceOptions tokenCacheOptions = new() { Name = Constants.TokenCacheName };
         credOptions.TokenCachePersistenceOptions = tokenCacheOptions;
         credOptions.AuthenticationRecord = await authenticationCacheManager.ReadAuthenticationRecordAsync(cancellationToken);
-        credOptions.LoginHint = credOptions.AuthenticationRecord?.Username;
 
         return new InteractiveBrowserCredential(credOptions);
     }


### PR DESCRIPTION
The login hint prevents users from selecting an AD account to use when logging in.